### PR TITLE
upgrading scala to 2.13.6

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -70,19 +70,20 @@
         <timestamp>${maven.build.timestamp}</timestamp>
         <maven.build.timestamp.format>yyyyMMddHHmm</maven.build.timestamp.format>
 
-        <scala.major.version>2.11</scala.major.version>
-        <scala.version>2.11.12</scala.version>
-        <scala.compat.version>2.11</scala.compat.version>
-        <scalatest.version>3.0.5</scalatest.version>
+        <scala.major.version>2.13</scala.major.version>
+        <scala.version>2.13.6</scala.version>
+        <scala.compat.version>2.13</scala.compat.version>
+        <scalatest.version>3.2.10</scalatest.version>
+        <scalatest-embedded-redis.version>0.4.0</scalatest-embedded-redis.version>
 
         <ubirch-uuid.version>0.1.5-SNAPSHOT</ubirch-uuid.version>
         <ubirch-redis.version>0.6.2-SNAPSHOT</ubirch-redis.version>
-        <akka.version>2.5.11</akka.version>
-        <redisson.version>3.7.5</redisson.version>
-        <rediscala.version>1.8.0</rediscala.version>
-        <scala-logging.version>3.9.0</scala-logging.version>
-        <slf4j.version>1.7.25</slf4j.version>
-        <logback.version>1.2.3</logback.version>
+        <akka.version>2.6.18</akka.version>
+        <redisson.version>3.16.7</redisson.version>
+        <rediscala.version>1.9.0</rediscala.version>
+        <scala-logging.version>3.9.4</scala-logging.version>
+        <slf4j.version>1.7.32</slf4j.version>
+        <logback.version>1.2.10</logback.version>
 
         <!-- plugins -->
         <maven-deploy-plugin.version>2.8.2</maven-deploy-plugin.version>
@@ -153,7 +154,7 @@
         <dependency>
             <groupId>com.github.sebruck</groupId>
             <artifactId>scalatest-embedded-redis_${scala.major.version}</artifactId>
-            <version>0.2.0</version>
+            <version>${scalatest-embedded-redis.version}</version>
             <scope>test</scope>
         </dependency>
         <!-- Logging -->

--- a/src/test/scala/com/ubirch/locking/AkkaLockManagerSpec.scala
+++ b/src/test/scala/com/ubirch/locking/AkkaLockManagerSpec.scala
@@ -6,7 +6,9 @@ import akka.testkit.{ImplicitSender, TestActors, TestKit}
 import akka.util.Timeout
 import com.github.sebruck.EmbeddedRedis
 import com.typesafe.scalalogging.StrictLogging
-import org.scalatest.{BeforeAndAfterAll, Matchers, WordSpecLike}
+import org.scalatest.BeforeAndAfterAll
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpecLike
 import redis.embedded.RedisServer
 
 import scala.concurrent.Await
@@ -15,7 +17,7 @@ import scala.language.postfixOps
 
 class AkkaLockManagerSpec extends TestKit(ActorSystem("MyTestSystem1")) with EmbeddedRedis
   with ImplicitSender
-  with WordSpecLike
+  with AnyWordSpecLike
   with BeforeAndAfterAll
   with Matchers
   with StrictLogging {
@@ -35,7 +37,7 @@ class AkkaLockManagerSpec extends TestKit(ActorSystem("MyTestSystem1")) with Emb
     lockActor2 = system2.actorOf(LockTesterActor.props())
   }
 
-  override def afterAll {
+  override def afterAll(): Unit = {
     TestKit.shutdownActorSystem(system)
     TestKit.shutdownActorSystem(system2)
     stopRedis(redis.get)
@@ -131,15 +133,15 @@ class LockTesterActor extends Actor
     case "lock" =>
       log.debug("try to get lock")
       if (lock)
-        sender ! "okay"
+        sender() ! "okay"
       else
-        sender ! "nok"
+        sender() ! "nok"
     case "unlock" =>
       log.debug("try unlock")
       if (unlock)
-        sender ! "okay"
+        sender() ! "okay"
       else
-        sender ! "nok"
+        sender() ! "nok"
   }
 }
 

--- a/src/test/scala/com/ubirch/locking/AkkaRedissonLocksSpec.scala
+++ b/src/test/scala/com/ubirch/locking/AkkaRedissonLocksSpec.scala
@@ -8,7 +8,9 @@ import com.github.sebruck.EmbeddedRedis
 import com.typesafe.scalalogging.StrictLogging
 import com.ubirch.locking.config.LockingConfig
 import org.redisson.api.RedissonClient
-import org.scalatest.{BeforeAndAfterAll, Matchers, WordSpecLike}
+import org.scalatest.BeforeAndAfterAll
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpecLike
 import redis.embedded.RedisServer
 
 import scala.concurrent.Await
@@ -17,7 +19,7 @@ import scala.language.postfixOps
 
 class AkkaRedissonLocksSpec extends TestKit(ActorSystem("MyTestSystem1")) with EmbeddedRedis
   with ImplicitSender
-  with WordSpecLike
+  with AnyWordSpecLike
   with BeforeAndAfterAll
   with Matchers
   with StrictLogging {
@@ -36,7 +38,7 @@ class AkkaRedissonLocksSpec extends TestKit(ActorSystem("MyTestSystem1")) with E
     lockActor2 = system2.actorOf(LockManagerTesterActor.props())
   }
 
-  override def afterAll {
+  override def afterAll(): Unit = {
     TestKit.shutdownActorSystem(system)
     TestKit.shutdownActorSystem(system2)
     stopRedis(redis.get)
@@ -136,18 +138,18 @@ class LockManagerTesterActor extends Actor with ActorLogging {
       log.debug("try to get lock")
       if (!redisson.getLock(lockName).isLocked) {
         redisson.getLock(lockName).tryLock()
-        sender ! "okay"
+        sender() ! "okay"
       }
       else
-        sender ! "nok"
+        sender() ! "nok"
     case "unlock" =>
       log.debug("try unlock")
       if (redisson.getLock(lockName).isLocked && redisson.getLock(lockName).isHeldByCurrentThread) {
         redisson.getLock(lockName).unlock()
-        sender ! "okay"
+        sender() ! "okay"
       }
       else
-        sender ! "nok"
+        sender() ! "nok"
   }
 }
 

--- a/src/test/scala/com/ubirch/locking/CounterManagerSpec.scala
+++ b/src/test/scala/com/ubirch/locking/CounterManagerSpec.scala
@@ -3,10 +3,12 @@ package com.ubirch.locking
 import com.github.sebruck.EmbeddedRedis
 import com.typesafe.scalalogging.StrictLogging
 import com.ubirch.util.uuid.UUIDUtil
-import org.scalatest.{BeforeAndAfterAll, FeatureSpec, Matchers}
+import org.scalatest.BeforeAndAfterAll
+import org.scalatest.featurespec.AnyFeatureSpec
+import org.scalatest.matchers.should.Matchers
 import redis.embedded.RedisServer
 
-class CounterManagerSpec extends FeatureSpec with EmbeddedRedis
+class CounterManagerSpec extends AnyFeatureSpec with EmbeddedRedis
   with BeforeAndAfterAll
   with StrictLogging
   with Matchers {
@@ -21,13 +23,13 @@ class CounterManagerSpec extends FeatureSpec with EmbeddedRedis
     counterManager = new CounterManagerImp()
   }
 
-  override def afterAll {
+  override def afterAll(): Unit = {
     stopRedis(redis.get)
   }
 
-  feature("basic test") {
+  Feature("basic test") {
 
-    scenario("inc/get/dec counter") {
+    Scenario("inc/get/dec counter") {
       val counterName = s"myLock-${UUIDUtil.uuidStr}"
       counterManager.inc(counterName) shouldBe 1L
       counterManager.inc(counterName) shouldBe 2L
@@ -42,7 +44,7 @@ class CounterManagerSpec extends FeatureSpec with EmbeddedRedis
       counterManager.get(counterName) shouldBe 0L
     }
 
-    scenario("inc/reset counter") {
+    Scenario("inc/reset counter") {
       val counterName = s"myLock-${UUIDUtil.uuidStr}"
       counterManager.inc(counterName) shouldBe 1L
       counterManager.inc(counterName) shouldBe 2L
@@ -56,7 +58,7 @@ class CounterManagerSpec extends FeatureSpec with EmbeddedRedis
     }
 
 
-    scenario("inc/get/dec counters") {
+    Scenario("inc/get/dec counters") {
       val counterNames = List(
         s"myLock-${UUIDUtil.uuidStr}",
         s"myLock-${UUIDUtil.uuidStr}",
@@ -86,7 +88,7 @@ class CounterManagerSpec extends FeatureSpec with EmbeddedRedis
       }
     }
 
-    scenario("inc/get/dec counters 2") {
+    Scenario("inc/get/dec counters 2") {
       val counterNames = List(
         s"myLock-${UUIDUtil.uuidStr}",
         s"myLock-${UUIDUtil.uuidStr}",

--- a/src/test/scala/com/ubirch/locking/LockManagerSpec.scala
+++ b/src/test/scala/com/ubirch/locking/LockManagerSpec.scala
@@ -2,10 +2,12 @@ package com.ubirch.locking
 
 import com.github.sebruck.EmbeddedRedis
 import com.ubirch.util.uuid.UUIDUtil
-import org.scalatest.{BeforeAndAfterAll, FeatureSpec, Matchers}
+import org.scalatest.BeforeAndAfterAll
+import org.scalatest.featurespec.AnyFeatureSpec
+import org.scalatest.matchers.should.Matchers
 import redis.embedded.RedisServer
 
-class LockManagerSpec extends FeatureSpec with EmbeddedRedis
+class LockManagerSpec extends AnyFeatureSpec with EmbeddedRedis
   with BeforeAndAfterAll
   with Matchers {
 
@@ -19,20 +21,20 @@ class LockManagerSpec extends FeatureSpec with EmbeddedRedis
     lockManager = new LockManagerImpl()
   }
 
-  override def afterAll {
+  override def afterAll(): Unit = {
     stopRedis(redis.get)
   }
 
 
-  feature("basic test") {
+  Feature("basic test") {
 
-    scenario("create a lock") {
+    Scenario("create a lock") {
       val lockName = s"myLock-${UUIDUtil.uuidStr}"
       lockManager.lock(lockName) shouldBe true
       lockManager.unlock(lockName) shouldBe true
     }
 
-    scenario("no lock") {
+    Scenario("no lock") {
       val lockName = s"myLock-${UUIDUtil.uuidStr}"
       lockManager.unlock(lockName) shouldBe false
     }

--- a/src/test/scala/com/ubirch/locking/RedissonLockSpec.scala
+++ b/src/test/scala/com/ubirch/locking/RedissonLockSpec.scala
@@ -4,10 +4,12 @@ import com.github.sebruck.EmbeddedRedis
 import com.typesafe.scalalogging.StrictLogging
 import com.ubirch.locking.config.LockingConfig
 import com.ubirch.util.uuid.UUIDUtil
-import org.scalatest.{BeforeAndAfterAll, FeatureSpec, Matchers}
+import org.scalatest.BeforeAndAfterAll
+import org.scalatest.featurespec.AnyFeatureSpec
+import org.scalatest.matchers.should.Matchers
 import redis.embedded.RedisServer
 
-class RedissonLockSpec extends FeatureSpec with EmbeddedRedis
+class RedissonLockSpec extends AnyFeatureSpec with EmbeddedRedis
   with StrictLogging
   with BeforeAndAfterAll
   with Matchers {
@@ -18,13 +20,13 @@ class RedissonLockSpec extends FeatureSpec with EmbeddedRedis
     redis = Some(startRedis(6379))
   }
 
-  override def afterAll {
+  override def afterAll(): Unit = {
     stopRedis(redis.get)
   }
 
-  feature("basic test") {
+  Feature("basic test") {
 
-    scenario("create a lock") {
+    Scenario("create a lock") {
 
       val lockName = s"myLock-${UUIDUtil.uuidStr}"
       val lock1 = LockingConfig.redisson.getLock(lockName)
@@ -34,14 +36,14 @@ class RedissonLockSpec extends FeatureSpec with EmbeddedRedis
       lock1.isLocked shouldBe false
     }
 
-    scenario("no lock") {
+    Scenario("no lock") {
 
       val lockName = s"myLock-${UUIDUtil.uuidStr}"
       val lock1 = LockingConfig.redisson.getLock(lockName)
       lock1.isLocked shouldBe false
     }
 
-    scenario("read/write lock") {
+    Scenario("read/write lock") {
 
       val lockName = s"myLock-${UUIDUtil.uuidStr}"
 
@@ -71,7 +73,7 @@ class RedissonLockSpec extends FeatureSpec with EmbeddedRedis
       lock1.writeLock().isLocked shouldBe false
     }
 
-    scenario("simple semaphore test") {
+    Scenario("simple semaphore test") {
 
       val semaphore = LockingConfig.redisson.getSemaphore("semaphore")
       semaphore.tryAcquire shouldBe false

--- a/src/test/scala/com/ubirch/locking/StaticLockManagerSpec.scala
+++ b/src/test/scala/com/ubirch/locking/StaticLockManagerSpec.scala
@@ -3,10 +3,12 @@ package com.ubirch.locking
 import com.github.sebruck.EmbeddedRedis
 import com.typesafe.scalalogging.StrictLogging
 import com.ubirch.util.uuid.UUIDUtil
-import org.scalatest.{BeforeAndAfterAll, FeatureSpec, Matchers}
+import org.scalatest.BeforeAndAfterAll
+import org.scalatest.featurespec.AnyFeatureSpec
+import org.scalatest.matchers.should.Matchers
 import redis.embedded.RedisServer
 
-class StaticLockManagerSpec extends FeatureSpec with EmbeddedRedis
+class StaticLockManagerSpec extends AnyFeatureSpec with EmbeddedRedis
   with BeforeAndAfterAll
   with StrictLogging
   with Matchers {
@@ -23,21 +25,21 @@ class StaticLockManagerSpec extends FeatureSpec with EmbeddedRedis
     lockManager = new StaticLockManagerImpl()
   }
 
-  override def afterAll {
+  override def afterAll(): Unit = {
     stopRedis(redis.get)
   }
 
 
-  feature("basic test") {
+  Feature("basic test") {
 
-    scenario("create a lock") {
+    Scenario("create a lock") {
       val lockName = s"myLock-${UUIDUtil.uuidStr}"
       val lock1 = lockManager.redisson.getLock(lockName)
       lockManager.lock shouldBe true
       lockManager.unlock shouldBe true
     }
 
-    scenario("no lock") {
+    Scenario("no lock") {
       lockManager.unlock shouldBe false
     }
 


### PR DESCRIPTION
- scala to 2.13.6
- scala-test to 3.2.10
- scala-logging 3.9.4
- akka to 2.6.18
- logback 1.2.10
- slf4j.api 1.7.32
- rediscala 1.9.0
- scalatest-embedded-redis 0.4.0